### PR TITLE
Improve release version handling

### DIFF
--- a/buildAndReleaseTask/VersionCreator.ts
+++ b/buildAndReleaseTask/VersionCreator.ts
@@ -11,6 +11,18 @@ export class VersionCreator {
         this.semverVersion = semverVersion;
     }
 
+    public getReleaseVersion(versionConfig: IVersionConfig): string | undefined {
+        const branch = tl.getVariable("Build.SourceBranch");
+        if (this.isReleaseVersion(versionConfig, branch)) {
+            return this.getVersion(versionConfig);
+        }
+        return undefined;
+    }
+
+    public isReleaseVersion(versionConfig: IVersionConfig, branch: string): boolean {
+        return versionConfig.releaseBranches && versionConfig.releaseBranches.some(x => new RegExp(x).test(branch));
+    }
+
     public getVersion(versionConfig: IVersionConfig): string {
 
         const branch = tl.getVariable("Build.SourceBranch");
@@ -19,7 +31,7 @@ export class VersionCreator {
             throw new Error("'Build.SourceBranch' is not set.");
         }
 
-        if (versionConfig.releaseBranches && versionConfig.releaseBranches.some(x => new RegExp(x).test(branch))) {
+        if (this.isReleaseVersion(versionConfig, branch)) {
             return versionConfig.version;
         }
         else {

--- a/buildAndReleaseTask/index.ts
+++ b/buildAndReleaseTask/index.ts
@@ -76,6 +76,16 @@ async function updateVersion(workDir: string, pathToVersionJson: string, semverV
     }
 
     let releaseVersion = versionCreator.getReleaseVersion(versionConfig);
+
+    if (releaseVersion !== undefined) {
+        const branch = tl.getVariable("Build.SourceBranch");
+        if (versionCreator.isReleaseVersion(versionConfig, branch)) {
+            if (branch.startsWith("refs/tags/") && !branch.endsWith(releaseVersion as string)) {
+                throw new Error(`The release version ${releaseVersion} does not match the tag ${branch}.`);
+            }
+        }
+    }
+
     return releaseVersion;
 }
 


### PR DESCRIPTION
This PR adds two changes:

1. If yavt is in multi mode and a configured version is a release version the build number will be set to this version instead of the last version found.
2. A new task input parameter `failOnTagVersionMismatch` was introduced which if set to true will lead to the task failing if the version of the git tag does not match the configured version if it is a release version.

I have not yet tested these changes as I'm not quite sure how to do that best. Is it possible to release a pre-release version so we can test it on one of the next fiskaltrust releases?

Thank you 🙏

Edit: And enjoy your vacation 🌴 If you see it please ignore that PR until you get back 😅 