### PR TITLE
Add splitFileVersion parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ steps:
     updateBuildNumber: true
     addCiLabel: true
     failOnTagVersionMismatch: true
-    semverVersion: 'v2'    
+    splitFileVersion: true
+    semverVersion: 'v2'
 ```
 
 ## Parameters
@@ -61,4 +62,5 @@ steps:
 - **`updateBuildNumber`**: If set to _true_, the build number in Azure DevOps is set to the computed version.
 - **`addCiLabel`**: If set to _true_, the postfix label `ci` will be set for PR builds if no other label is specified. For example, creating a PR build with the specified version `1.0.0` will result in `1.0.0-ci.20045.123`. When the label is already set in `version.json`, e.g. to `1.0.0-rc1`, it will be respected and the resulting version will be  `1.0.0-rc1.20045.123`.
 - **`failOnTagVersionMismatch`**: If set to _true_, fail when a release version is created, but the tag and the version don't match.
+- **`splitFileVersion`**: If set to true the build number will be split up into two parts and used for the minor and patch parts of the file version. This mitigates error CS7035 on build numbers higher than 65534.
 - **`semverVersion`**: If v1 is selected, labels are separated by a `-` instead of a `.` - e.g. `1.0.0-rc1-20123-42` instead of `1.0.0-rc1.20123.42`.

--- a/buildAndReleaseTask/BuildPropsVersionManager.ts
+++ b/buildAndReleaseTask/BuildPropsVersionManager.ts
@@ -76,6 +76,7 @@ export class BuildPropsVersionManager {
 
         const version = this.versionCreator.getVersion(versionConfig);
         const fileVersion = this.versionCreator.getFileVersion(versionConfig);
+        const assemblyVersion = this.versionCreator.getAssemblyVersion(versionConfig);
 
         if (xml.Project.PropertyGroup) {
             const propertyGroupWithVersion = xml.Project.PropertyGroup.filter((x: any) => x.Version);
@@ -95,13 +96,22 @@ export class BuildPropsVersionManager {
                 const propertyGroupFile = { FileVersion: fileVersion };
                 xml.Project.PropertyGroup.push(propertyGroupFile);
             }
+
+            const propertyGroupWithAssemblyVersion = xml.Project.PropertyGroup.filter((x: any) => x.AssemblyVersion);
+            if (propertyGroupWithAssemblyVersion && propertyGroupWithAssemblyVersion.length) {
+                propertyGroupWithAssemblyVersion[0].AssemblyVersion = assemblyVersion;
+            }
+            else {
+                const propertyGroupAssembly = { AssemblyVersion: assemblyVersion };
+                xml.Project.PropertyGroup.push(propertyGroupAssembly);
+            }
         }
         else {
             if (typeof xml.Project === 'string' || xml.Project instanceof String) {
-                xml.Project = { PropertyGroup: { Version: version, FileVersion: fileVersion } };
+                xml.Project = { PropertyGroup: { Version: version, FileVersion: fileVersion, AssemblyVersion: assemblyVersion } };
             }
             else {
-                xml.Project.PropertyGroup = { Version: version, FileVersion: fileVersion };
+                xml.Project.PropertyGroup = { Version: version, FileVersion: fileVersion, AssemblyVersion: assemblyVersion };
             }
         }
 
@@ -112,7 +122,8 @@ export class BuildPropsVersionManager {
 
         const version = this.versionCreator.getVersion(versionConfig);
         const fileVersion = this.versionCreator.getFileVersion(versionConfig);
+        const assemblyVersion = this.versionCreator.getAssemblyVersion(versionConfig);
 
-        return { Project: { PropertyGroup: { Version: version, FileVersion: fileVersion } } };
+        return { Project: { PropertyGroup: { Version: version, FileVersion: fileVersion, AssemblyVersion: assemblyVersion } } };
     }
 }

--- a/buildAndReleaseTask/VersionCreator.ts
+++ b/buildAndReleaseTask/VersionCreator.ts
@@ -59,7 +59,10 @@ export class VersionCreator {
     public getFileVersion(versionConfig: IVersionConfig): string {
         const buildId = tl.getVariable("Build.BuildId");
         let version: string;
-
+        if (buildId == undefined) {
+            throw new Error("'Build.BuildId' is not set.");
+        }
+        
         if (versionConfig.version.includes("-")) {
             version = versionConfig.version.substring(0, versionConfig.version.indexOf('-'));
         }

--- a/buildAndReleaseTask/VersionCreator.ts
+++ b/buildAndReleaseTask/VersionCreator.ts
@@ -4,11 +4,13 @@ import { IVersionConfig } from "./IVersionConfig";
 export class VersionCreator {
 
     private addCiLabel: boolean;
+    private splitFileVersion: boolean;
     private semverVersion: string;
 
-    constructor(addCiLabel: boolean, semverVersion: string) {
+    constructor(addCiLabel: boolean, semverVersion: string, splitFileVersion: boolean) {
         this.addCiLabel = addCiLabel;
         this.semverVersion = semverVersion;
+        this.splitFileVersion = splitFileVersion;
     }
 
     public getReleaseVersion(versionConfig: IVersionConfig): string | undefined {
@@ -55,7 +57,6 @@ export class VersionCreator {
     }
 
     public getFileVersion(versionConfig: IVersionConfig): string {
-
         const buildId = tl.getVariable("Build.BuildId");
         let version: string;
 
@@ -66,7 +67,17 @@ export class VersionCreator {
             version = versionConfig.version;
         }
 
-        return `${version}.${buildId}`
+        if (this.splitFileVersion) {
+            const versionParts = version.split(".");
+            version = `${versionParts[0]}.${versionParts[1]}`;
+
+            const buildIdString = buildId.toString();
+            const buildIdSplit = `${buildIdString.substring(0, buildIdString.length - 4)}.${buildIdString.substring(buildIdString.length - 4)}`;
+
+            return `${version}.${buildIdSplit}`;
+        } else {
+            return `${version}.${buildId}`;
+        }
     }
 
     private versionHasPostfix(version: string): boolean {

--- a/buildAndReleaseTask/VersionCreator.ts
+++ b/buildAndReleaseTask/VersionCreator.ts
@@ -80,6 +80,20 @@ export class VersionCreator {
         }
     }
 
+    public getAssemblyVersion(versionConfig: IVersionConfig): string {
+        let version: string;
+
+        if (versionConfig.version.includes("-")) {
+            version = versionConfig.version.substring(0, versionConfig.version.indexOf('-'));
+        }
+        else {
+            version = versionConfig.version;
+        }
+
+        return `${version}.0`;
+    }
+
+
     private versionHasPostfix(version: string): boolean {
 
         return version.includes("-");

--- a/buildAndReleaseTask/index.ts
+++ b/buildAndReleaseTask/index.ts
@@ -18,6 +18,7 @@ async function run() {
         const includeParentProps: boolean = tl.getBoolInput('includeParentProps', true);
         const addCiLabel: boolean = tl.getBoolInput('addCiLabel', true);
         const failOnTagVersionMismatch: boolean = tl.getBoolInput('failOnTagVersionMismatch', true);
+        const splitFileVersion: boolean = tl.getBoolInput('splitFileVersion', true);
 
         if (pathToVersionJson === undefined) {
             tl.setResult(tl.TaskResult.Failed, "The input 'pathToVersionJson' is required.");
@@ -33,7 +34,7 @@ async function run() {
         }
 
         if (mode == "Single") {
-            await updateVersion("./", pathToVersionJson, semverVersion, updateNuspecFiles, updateBuildNumber, addCiLabel, includeParentProps, false, failOnTagVersionMismatch);
+            await updateVersion("./", pathToVersionJson, semverVersion, updateNuspecFiles, updateBuildNumber, addCiLabel, includeParentProps, false, failOnTagVersionMismatch, splitFileVersion);
         }
         else {
             let files = await glob("**/version.json");
@@ -45,7 +46,7 @@ async function run() {
 
             for (const file of files) {
                 const workDir = path.dirname(file);
-                const innerReleasVersion = await updateVersion(workDir, file, semverVersion, updateNuspecFiles, updateBuildNumber, addCiLabel, includeParentProps, true, failOnTagVersionMismatch);
+                const innerReleasVersion = await updateVersion(workDir, file, semverVersion, updateNuspecFiles, updateBuildNumber, addCiLabel, includeParentProps, true, failOnTagVersionMismatch, splitFileVersion);
                 releaseVersion ??= innerReleasVersion;
             }
 
@@ -59,11 +60,11 @@ async function run() {
     }
 }
 
-async function updateVersion(workDir: string, pathToVersionJson: string, semverVersion: string, updateNuspecFiles: boolean, updateBuildNumber: boolean, addCiLabel: boolean, includeParentProps: boolean, isMultiMode: boolean, failOnTagVersionMismatch: boolean): Promise<string | undefined> {
+async function updateVersion(workDir: string, pathToVersionJson: string, semverVersion: string, updateNuspecFiles: boolean, updateBuildNumber: boolean, addCiLabel: boolean, includeParentProps: boolean, isMultiMode: boolean, failOnTagVersionMismatch: boolean, splitFileVersion: boolean): Promise<string | undefined> {
     const versionContent = await fs.promises.readFile(pathToVersionJson, "utf8");
     const versionConfig: IVersionConfig = JSON.parse(versionContent);
 
-    const versionCreator = new VersionCreator(addCiLabel, semverVersion);
+    const versionCreator = new VersionCreator(addCiLabel, semverVersion, splitFileVersion);
     const buildPropsVersionManager = new BuildPropsVersionManager(versionCreator);
 
     if (updateBuildNumber) {

--- a/buildAndReleaseTask/package.json
+++ b/buildAndReleaseTask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yavt",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Yet another versioning tool - Git versioning, simple and configurable",
   "main": "index.js",
   "scripts": {

--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -9,8 +9,8 @@
     "author": "tschmiedlechner",
     "version": {
         "Major": 1,
-        "Minor": 6,
-        "Patch": 1
+        "Minor": 7,
+        "Patch": 0
     },
     "instanceNameFormat": "Set versions",
     "inputs": [
@@ -74,6 +74,14 @@
             "defaultValue": true,
             "required": false,
             "helpMarkDown": "Fail when a release version is created, but the tag and the version don't match"
+        },
+        {
+            "name": "splitFileVersion",
+            "type": "boolean",
+            "label": "Split up the build number for the minor and patch parts of the file version",
+            "defaultValue": true,
+            "required": false,
+            "helpMarkDown": "Can be used to fix build error CS7035"
         },
         {
             "name": "semverVersion",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "yavt",
     "name": "YAVT - Yet another versioning tool",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "publisher": "tschmiedlechner",
     "targets": [
         {


### PR DESCRIPTION
This add a parameter `splitFileVersion` which if set to true will change the `FileVersion` to the following format:

```
<major>.<minor>.<buildId.substr(0, -5)>.<buildId.substr(-4,-1)>
```

Example:
* version: 1.2.3
* buildId: 345678

results in `FileVersion`
```
1.2.34.5678
```

This solves the error `CS7035: The specified version string '1.3.3.65538' does not conform to the recommended format - major.minor.build.revision` if the buildId is greater than 65534.